### PR TITLE
Failed ticket parsing should raise exception

### DIFF
--- a/master/buildbot/changes/p4poller.py
+++ b/master/buildbot/changes/p4poller.py
@@ -201,6 +201,7 @@ class P4Source(base.PollingChangeSource, util.ComparableMixin):
     def _parseTicketPassword(self, text):
         lines = text.split("\n")
         if len(lines) < 3:
+            raise P4PollerError("Failed to parse ticket in that output is less than 3 lines: {}".format(text))
             return None
         return lines[2].strip()
 


### PR DESCRIPTION
## Contributor Checklist:

* [] I have updated the unit tests
* [] I have created a file in the `master/buildbot/newsfragment` directory (and read the `README.txt` in that directory)
* [] I have updated the appropriate documentation
